### PR TITLE
Only prompt for choice if called interactively

### DIFF
--- a/etc/pyenv.d/which/whence.bash
+++ b/etc/pyenv.d/which/whence.bash
@@ -1,4 +1,4 @@
-if [ -n "$PYENV_COMMAND" ] && [ ! -x "$PYENV_COMMAND_PATH" ]; then
+if [ -t 1 ] && [ -n "$PYENV_COMMAND" ] && [ ! -x "$PYENV_COMMAND_PATH" ]; then
   versions=($(pyenv-whence "${PYENV_COMMAND}" 2>/dev/null || true))
   if [ -n "${versions}" ]; then
     if [ "${#versions[@]}" -gt 1 ]; then


### PR DESCRIPTION
Testing stdin is attached to a terminal makes the plugin compatible with scripted pyenv use (e.g. via pyenv-implicit) with no impact on its normal functionality.

Thanks for sharing your code! :smile:
